### PR TITLE
Generalização da URL do aplicativo para os links enviados via e-mail

### DIFF
--- a/app/Models/Chat.php
+++ b/app/Models/Chat.php
@@ -29,7 +29,7 @@ class Chat extends Model
     //Função para modificar a mensagem padrão do chat
     public static function configChatMail($pedido, $usuario, $chat){
         $settings = new GeneralSettings;
-        $url = "<a href='http://grafica.fflch.usp.br/pedidos/{$pedido->id}'>Link do pedido</a>'";
+        $url = "<a href='" . config('grafica.app_url') . "/pedidos/{$pedido->id}'>Link do pedido</a>'";
         $mensagem = $settings->chat;
         //Busca a última configuração
         $mensagem = str_replace(

--- a/app/Models/Pedido.php
+++ b/app/Models/Pedido.php
@@ -104,7 +104,7 @@ class Pedido extends Model
     //Função para modificar a mensagem padrão dos emails
     public static function configMail($pedido, $usuario, $tipo){
         $settings = new GeneralSettings;
-        $url = "<a href='http://grafica.fflch.usp.br/pedidos/{$pedido->id}'>Link do pedido</a>'";
+        $url = "<a href='" . config('grafica.app_url') . "/pedidos/{$pedido->id}'>Link do pedido</a>'";
         if($tipo == 'em_analise'){
             $mensagem = $settings->em_analise;
         }

--- a/config/grafica.php
+++ b/config/grafica.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    # URL da ferramenta Gráfica hospedada para o respectivo Instituto. 
+    'app_url' => env('APP_URL')
+    
+];


### PR DESCRIPTION
Fix #3 
 - Antes, a URL era fixa segundo a URL do sistema da FFLCH;
 - Agora, a URL definida na variável de ambiente APP_URL define os links enviados aos e-mails;
 - Para tanto, foi criado o config/grafica.php que busca essa informação do .env e repassa para o cliente.